### PR TITLE
fix: Removed confirmation section from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -38,10 +38,3 @@ body:
       render: shell
     validations:
       required: true
-  - type: checkboxes
-    id: confirmations
-    attributes:
-      label: Confirmations
-      options:
-        - label: I searched existing issues and didn’t find a match
-          required: true

--- a/.github/workflows/api-validation.yml
+++ b/.github/workflows/api-validation.yml
@@ -13,7 +13,6 @@ on:
         - 'pinecone-only'
         - 'github-only'
         - 'gemini-only'
-
 permissions:
   issues: read
   contents: read


### PR DESCRIPTION
# Summary
Remove the redundant “Confirmations” checklist from the bug report template ([.github/ISSUE_TEMPLATE/bug_report.yml](cci:7://file:///d:/GSOC/seroski-dupbot/.github/ISSUE_TEMPLATE/bug_report.yml:0:0-0:0)) since the bot in [.github/scripts/check-duplicates.js](cci:7://file:///d:/GSOC/seroski-dupbot/.github/scripts/check-duplicates.js:0:0-0:0) automatically detects duplicate issues. This streamlines issue creation and reduces contributor friction.

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Chore

## Linked issue(s)
Closes #<issue-number-if-tracked>
Related to #<issue-number-if-any>

## How to test
1. Open “New issue” and choose “Bug report”.
2. Verify the form no longer includes the “Confirmations” section asking to search existing issues.
3. Submit an issue and observe that the duplicate detection workflow still runs as usual.

Expected outcome:
- The “Confirmations” checkbox is not present.
- Duplicate detection still comments/labels as configured by [.github/workflows/duplicate-issue.yml](cci:7://file:///d:/GSOC/seroski-dupbot/.github/workflows/duplicate-issue.yml:0:0-0:0).

## Screenshots / Logs (if relevant)
<attach or paste if needed>

## Breaking changes
- [x] None

## Checklist
- [x] I updated docs or comments where needed (issue template)
- [ ] I have run linters/tests locally
- [ ] I added/updated acceptance tests or examples if applicable
- [x] I added appropriate labels (docs)
- [x] I confirmed no sensitive data is committed