### PR TITLE
docs: add CODE_OF_CONDUCT.md and update contributing and readme links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -29,7 +29,7 @@ If you believe someone is violating this Code of Conduct, please report it to th
 
 You may contact either address for private reports.
 
-Include as much information as possible (what happened, when, links, screenshots). Reports will be handled promptly and with respect for the reporter's privacy. If you prefer, you may open a private GitHub issue or contact a maintainer off-band.
+Include as much information as possible (what happened, when, links, screenshots). Reports will be handled promptly and with respect for the reporter's privacy. If you prefer, you may open a private GitHub issue or contact a maintainer out-of-band.
 
 ### Enforcement
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,47 @@
+## Contributor Covenant Code of Conduct (v2.1)
+
+This project and everyone participating in it is governed by the Contributor Covenant v2.1. By participating, you are expected to uphold this code. Be kind and respectful to others.
+
+Full text and details: https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+
+### Our standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior by participants include:
+
+- Harassment, intimidation, or exclusionary behavior
+- Violent or sexual language and imagery in public spaces
+- Posting others' private information (doxing)
+- Personal insults, sustained disruption of discussion, or advocating real-world harm
+
+### Reporting
+
+If you believe someone is violating this Code of Conduct, please report it to the project maintainers at one of the following email addresses:
+
+- arun.ofc09@gmail.com
+- jasonwilliam9894@gmail.com
+
+You may contact either address for private reports.
+
+Include as much information as possible (what happened, when, links, screenshots). Reports will be handled promptly and with respect for the reporter's privacy. If you prefer, you may open a private GitHub issue or contact a maintainer off-band.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at the email above. All reports will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The maintainers are responsible for determining and implementing consequences, up to and including removal from the project or repository.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+### Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1, available at https://www.contributor-covenant.org
+
+---
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,8 @@ By participating in this project, you agree to maintain a respectful and inclusi
 - Focus on constructive feedback
 - Respect differing opinions and experiences
 
+Please also read our full Code of Conduct: [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
+
 ## 🚀 Getting Started
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![GitHub Actions](https://img.shields.io/github/actions/workflow/status/seroski-ai/seroski-dupbot/duplicate-issue.yml?branch=main)](https://github.com/seroski-ai/seroski-dupbot/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Code of Conduct](https://img.shields.io/badge/code%20of%20conduct-contributor%20covenant-blue.svg)](./CODE_OF_CONDUCT.md)
 
 ## 🎯 What It Does
 


### PR DESCRIPTION
## Summary
Added a Code of Conduct to establish community standards and updated documentation to reference it. This clarifies expected behavior, provides reporting contacts, and improves project professionalism & contributor experience.

**Changes:**
- Added `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1, adapted)
- Added reporting contact emails to `CODE_OF_CONDUCT.md`: `arun.ofc09@gmail.com` and `jasonwilliam9894@gmail.com`
- Added a short link to the Code of Conduct in `CONTRIBUTING.md`
- Added a Code of Conduct badge/link to `README.md`
- Branch: `add-code-of-conduct`

## Why this is needed
- Encourages respectful and inclusive communication
- Makes reporting and enforcement clear for maintainers and contributors
- Required/expected by many open-source programs and platforms

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Chore
- [x] Docs

## Linked issue(s)
Closes #42 
Related to #42 

## How to test
1. Checkout the working branch locally and view the updated files:

```bash
git fetch origin
git checkout add-code-of-conduct
```

2. Verify the new file exists and contains the Contributor Covenant content:

```bash
ls -l CODE_OF_CONDUCT.md
sed -n '1,120p' CODE_OF_CONDUCT.md   # view top of file
```

3. Verify `CONTRIBUTING.md` includes the Code of Conduct link:

```bash
grep -n "CODE_OF_CONDUCT.md" CONTRIBUTING.md || true
```

4. Verify `README.md` has the Code of Conduct badge:

```bash
grep -n "code%20of%20conduct" README.md || true
```

5. Optionally run project validations (if applicable):

```bash
npm install
npm run validate
# or run any repo-specific linters/tests you use
```

## Expected outcome
- `CODE_OF_CONDUCT.md` is present and readable in the repo root.
- `CONTRIBUTING.md` contains a link to the Code of Conduct.
- `README.md` displays a Code of Conduct badge/link.
- Reporting contacts are listed in `CODE_OF_CONDUCT.md`.

## Screenshots / Logs (if relevant)
No UI changes; nothing to attach.

## Breaking changes
- [x] None

## Checklist
- [ ] I have run linters/tests locally
- [x] I updated docs or comments where needed
- [ ] I added/updated acceptance tests or examples if applicable
- [ ] I added appropriate labels (bug/enhancement/docs)
- [x] I confirmed no sensitive data is committed

## Notes
- The Code of Conduct lists reporting emails `arun.ofc09@gmail.com` and `jasonwilliam9894@gmail.com`. If you'd rather use a dedicated alias or repository maintainer email (e.g., security@ or conduct@), update `CODE_OF_CONDUCT.md` before merging.
- I can prepare a follow-up PR for `SECURITY.md` next, as discussed.

---