### PR TITLE
added security policy for the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![GitHub Actions](https://img.shields.io/github/actions/workflow/status/seroski-ai/seroski-dupbot/duplicate-issue.yml?branch=main)](https://github.com/seroski-ai/seroski-dupbot/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Code of Conduct](https://img.shields.io/badge/code%20of%20conduct-contributor%20covenant-blue.svg)](./CODE_OF_CONDUCT.md)
+[![Security Policy](https://img.shields.io/badge/security-policy-red.svg)](./SECURITY.md)
 
 ## 🎯 What It Does
 
@@ -103,6 +104,17 @@ npm run check-duplicates
 ## 🛠️ Advanced Usage
 
 For detailed workflow management and troubleshooting, see [WORKFLOWS.md](./WORKFLOWS.md)
+
+## 🔒 Security
+
+Security is a top priority. Please review our [Security Policy](./SECURITY.md) for:
+
+- **Vulnerability Reporting**: How to responsibly report security issues
+- **API Key Safety**: Best practices for handling secrets and credentials
+- **Response Timeline**: What to expect when reporting vulnerabilities
+- **Security Checklist**: Guidelines for safe deployment
+
+**Found a security issue?** Please report it privately to arun.ofc09@gmail.com or jasonwilliam9894@gmail.com
 
 ## 🆘 Troubleshooting
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,159 @@
+# 🔒 Security Policy
+
+## Reporting Security Vulnerabilities
+
+We take the security of Seroski-DupBot seriously. If you discover a security vulnerability, please report it responsibly.
+
+### How to Report
+
+**Please DO NOT report security vulnerabilities through public GitHub issues.**
+
+Instead, please report security vulnerabilities by emailing one of the following addresses:
+
+- **arun.ofc09@gmail.com**
+- **jasonwilliam9894@gmail.com**
+
+Include as much information as possible:
+
+- **Type of vulnerability** (e.g., API key exposure, injection, authentication bypass)
+- **Steps to reproduce** the issue
+- **Affected versions** or components
+- **Potential impact** of the vulnerability
+- **Suggested fix** (if you have one)
+
+### What to Expect
+
+- **Initial Response**: We will acknowledge receipt of your report within **48 hours**
+- **Status Updates**: We will provide status updates every **5-7 business days**
+- **Resolution Timeline**: We aim to resolve critical vulnerabilities within **30 days**
+- **Credit**: We will credit you in the security advisory (unless you prefer to remain anonymous)
+
+### Disclosure Policy
+
+- Please allow us reasonable time to fix the issue before public disclosure
+- We will coordinate with you on the disclosure timeline
+- We will publish a security advisory once a fix is available
+
+## Supported Versions
+
+We currently support security updates for the following versions:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Security Best Practices
+
+### For Contributors and Users
+
+#### API Keys and Secrets
+
+**Never commit sensitive credentials to the repository.** Always use environment variables or GitHub Secrets.
+
+✅ **DO:**
+```bash
+# Use .env file (never commit this file)
+GITHUB_TOKEN=your_token_here
+GEMINI_API_KEY=your_api_key_here
+PINECONE_API_KEY=your_api_key_here
+```
+
+❌ **DON'T:**
+```javascript
+// Never hardcode credentials
+const apiKey = "AIzaSyAbc123...";  // BAD!
+```
+
+#### Rotating Tokens
+
+If you suspect a token or API key has been compromised:
+
+1. **Revoke** the compromised key immediately
+2. **Generate** a new key
+3. **Update** your GitHub Secrets or local `.env` file
+4. **Test** that the new key works
+5. **Report** the incident if the key was committed to the repository
+
+#### GitHub Actions Secrets
+
+When using this bot in your repository:
+
+1. Store all API keys in **GitHub Secrets** (Settings → Secrets and variables → Actions)
+2. Never log or print secret values in workflows
+3. Limit secret access to specific workflows when possible
+4. Regularly rotate API keys (every 90 days recommended)
+
+#### Pinecone Database Security
+
+- Use **API key authentication** (enabled by default)
+- Restrict API keys to specific indexes when possible
+- Monitor database access logs for unusual activity
+- Delete test/development indexes when no longer needed
+
+### For Maintainers
+
+- Review all PRs for potential security issues before merging
+- Run security audits regularly: `npm audit`
+- Keep dependencies up to date
+- Use Dependabot for automated security updates
+- Enable branch protection on `main` branch
+- Require code reviews for all changes
+
+## Known Security Considerations
+
+### API Rate Limits
+
+- **Google Gemini**: Rate limits apply based on your API tier
+- **Pinecone**: Rate limits apply based on your plan
+- **GitHub API**: Rate limits apply (5,000 requests/hour for authenticated requests)
+
+Implement proper error handling and backoff strategies to avoid service disruptions.
+
+### Data Privacy
+
+- Issue data is stored in Pinecone vector database
+- Only public issue data is processed
+- No personal information beyond what's in public issues is collected
+- Database vectors can be cleared using cleanup scripts
+
+### Environment Variables
+
+The following environment variables contain sensitive data:
+
+- `GITHUB_TOKEN` - GitHub personal access token or GitHub Actions token
+- `GEMINI_API_KEY` - Google Gemini API key
+- `PINECONE_API_KEY` - Pinecone database API key
+
+**Never share these values or commit them to version control.**
+
+## Security Checklist for Deployments
+
+Before deploying or using this bot:
+
+- [ ] All API keys stored in GitHub Secrets (not hardcoded)
+- [ ] `.env.demo` does not contain real credentials
+- [ ] `.gitignore` includes `.env` file
+- [ ] Workflow permissions are set to minimum required
+- [ ] API validation workflow passes
+- [ ] Dependencies are up to date (`npm audit` clean)
+- [ ] No sensitive data in commit history
+
+## Additional Resources
+
+- [GitHub Security Best Practices](https://docs.github.com/en/code-security)
+- [OWASP API Security](https://owasp.org/www-project-api-security/)
+- [Pinecone Security Documentation](https://docs.pinecone.io/docs/security)
+- [Google Cloud Security](https://cloud.google.com/security/best-practices)
+
+## Security Hall of Fame
+
+We appreciate security researchers who responsibly disclose vulnerabilities:
+
+- *Your name could be here!*
+
+---
+
+**Questions about security?** Contact us at arun.ofc09@gmail.com or jasonwilliam9894@gmail.com
+
+Thank you for helping keep Seroski-DupBot and our community safe! 🛡️


### PR DESCRIPTION
## Summary
Added a comprehensive Security Policy to define vulnerability reporting procedures, response timelines, and security best practices for the project. This improves project credibility, enables GitHub's Security tab, and encourages responsible disclosure.

**Changes:**
- Added `SECURITY.md` with detailed security policy including:
  - Vulnerability reporting process (private email reporting)
  - Expected response times (48hr acknowledgment, 30-day resolution target)
  - Security best practices for API keys, secrets, and credentials
  - Safe handling guidelines for GitHub Actions, Pinecone, and Gemini API
  - Security checklist for deployments
- Added Security Policy badge to `README.md`
- Added Security section in `README.md` linking to `SECURITY.md`
- Contact emails: `arun.ofc09@gmail.com` and `jasonwilliam9894@gmail.com`
- Branch: `add-security-policy`

## Why this is needed
- Defines a clear vulnerability reporting process
- Enables GitHub's "Security" tab visibility
- Improves project credibility and compliance
- Encourages responsible disclosure rather than public issue posting
- Provides clear guidelines for handling sensitive data (API keys, tokens, credentials)

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Chore
- [x] Docs

## Linked issue(s)
Closes #44 

## How to test

1. Checkout the working branch locally and view the updated files:

```bash
git fetch origin
git checkout add-security-policy
```

2. Verify `SECURITY.md` exists and contains comprehensive security policy:

```bash
ls -l SECURITY.md
head -50 SECURITY.md
```

3. Verify `README.md` has the Security Policy badge:

```bash
grep -n "Security Policy" README.md || true
grep -n "security-policy-red" README.md || true
```

4. Verify `README.md` includes the Security section:

```bash
grep -A 10 "## 🔒 Security" README.md || true
```

5. Check that GitHub's Security tab will be enabled (appears once merged to main):
   - Navigate to repository → Security tab (will show "Set up a security policy" before merge)
   - After merge, the Security tab will link to `SECURITY.md`

## Expected outcome
- `SECURITY.md` is present and readable in the repo root
- README.md displays a Security Policy badge
- README.md includes a Security section with links and contact info
- GitHub Security tab becomes available (after merge to main)
- Clear reporting process for vulnerabilities is documented

## Screenshots / Logs (if relevant)

Security policy includes:
- ✅ Vulnerability reporting process (private email)
- ✅ Response timeline (48hr ack, 30-day resolution)
- ✅ API key safety best practices
- ✅ Token rotation guidelines
- ✅ GitHub Actions security checklist
- ✅ Data privacy considerations
- ✅ Security checklist for deployments

## Breaking changes
- [x] None

## Checklist
- [ ] I have run linters/tests locally
- [x] I updated docs or comments where needed
- [ ] I added/updated acceptance tests or examples if applicable
- [ ] I added appropriate labels (bug/enhancement/docs)
- [x] I confirmed no sensitive data is committed

## Notes

- The Security Policy lists reporting emails `arun.ofc09@gmail.com` and `jasonwilliam9894@gmail.com`. These are the same contacts as in `CODE_OF_CONDUCT.md`.
- Consider enabling:
  - GitHub Dependabot alerts (Settings → Security → Code security and analysis)
  - GitHub Secret scanning (Settings → Security → Code security and analysis)
  - GitHub Security advisories (Security tab → Advisories)
- After merge, the Security tab will be visible in the repository

## Related
- Part of improving repository governance and community standards

---